### PR TITLE
Using builtin decoder in gui

### DIFF
--- a/bin/build-aruspix
+++ b/bin/build-aruspix
@@ -22,8 +22,8 @@ mkdir -p $guidir/build && cd $guidir/build
 cmake /build/aruspix/linux \
       -DwxDir=/usr/local/bin \
       -DimDir=/build/im \
+      -DtorchDir=/build/Torch3
       
-
 make -j 4
 
 # Copy binary and static files.

--- a/bin/build-aruspix
+++ b/bin/build-aruspix
@@ -21,7 +21,8 @@ mkdir -p $guidir/build && cd $guidir/build
 
 cmake /build/aruspix/linux \
       -DwxDir=/usr/local/bin \
-      -DimDir=/build/im
+      -DimDir=/build/im \
+      
 
 make -j 4
 
@@ -60,7 +61,7 @@ mkdir -p $cmddir/build && cd $cmddir/build
 cmake /build/aruspix/cmd-line \
       -DwxDir=/usr/local/bin \
       -DimDir=/build/im \
-      -DtorchDir=/build/Torch3 \
+      -DtorchDir=/build/Torch3
 
 make -j 4
 


### PR DESCRIPTION
This fixes the recognition problem in the gui build. It works with the https://github.com/DDMAL/aruspix/tree/ubuntu-16.04 branch.

Because a builtin decoder is used, the torch library need to be passed to the makefile